### PR TITLE
Hotfix: 扩展内置地址的来源，尽量避免 `query()` 接口被限流

### DIFF
--- a/src/core/check-tx.js
+++ b/src/core/check-tx.js
@@ -3,8 +3,8 @@ import * as config from './config'
 import { isValidPayId } from '../util'
 import * as error from '../const/error'
 import * as ua from '../ua/index'
-import * as _addr from '../util/addr'
 import * as util from '../util/index'
+import * as _addr from '../util/addr'
 
 /*
 当交易查询成功时，nebPay.queryPayInfo() 的返回值是一个 JSON 字符串，格式为： {

--- a/src/core/check-tx.js
+++ b/src/core/check-tx.js
@@ -3,6 +3,8 @@ import * as config from './config'
 import { isValidPayId } from '../util'
 import * as error from '../const/error'
 import * as ua from '../ua/index'
+import * as _addr from '../util/addr'
+import * as util from '../util/index'
 
 /*
 当交易查询成功时，nebPay.queryPayInfo() 的返回值是一个 JSON 字符串，格式为： {
@@ -87,6 +89,7 @@ export function checkTx(sn, options = {}) {
 								result = null
 							}
 							txData.result = result
+							saveUserAddr(txData)
 							resolve(txData)
 						} else if (txData.status === 2) {
 							retry()
@@ -118,6 +121,12 @@ export function checkTx(sn, options = {}) {
 			} else {
 				setTimeout(check, interval * 1000)
 			}
+		}
+
+		// 把用户的钱包地址缓存下来
+		function saveUserAddr(data) {
+			const addr = data.from
+			if (util.isValidAddr(addr)) _addr.setAvailableAddr(addr)
 		}
 	})
 }

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -1,8 +1,6 @@
 /* global NebPay */
 import * as env from '../env/index'
 
-const DEFAULT_ADDR = 'n1bCep7RbeCWQk9EQo48V3TuXEdZLCS7eTn'
-
 const nebConfig = NebPay.config
 
 const NEBULAS = {
@@ -35,7 +33,6 @@ function getNebPayOptions() {
 }
 
 export {
-	DEFAULT_ADDR,
 	getNebPayOptions,
 	get,
 }

--- a/src/core/query.js
+++ b/src/core/query.js
@@ -1,6 +1,7 @@
 import * as config from './config'
 import { get as getContract } from '../contract/index'
-import { isValidAddr } from '../util'
+import { isValidAddr } from '../util/index'
+import * as addr from '../util/addr'
 import * as error from '../const/error'
 
 /*
@@ -20,6 +21,10 @@ import * as error from '../const/error'
 	execute_err: "insufficient balance",
 	result: "...json string...",
 }
+
+当请求所用的地址非法：400 error: {
+	error: 'address: invalid address type',
+}
 */
 
 export function query(contractAddr, fnName, args = []) {
@@ -32,9 +37,12 @@ export function query(contractAddr, fnName, args = []) {
 		return Promise.reject(new Error(error.INVALID_ARG))
 	}
 
+	const randomAddr = addr.getAvailableAddr()
+	// console.log(randomAddr)
+
 	const api = config.get('apiBaseUrl') + 'user/call'
 	const txParams = {
-		from: config.DEFAULT_ADDR,
+		from: randomAddr,
 		to: contract,
 		value: '0',
 		nonce: '0',
@@ -57,6 +65,7 @@ export function query(contractAddr, fnName, args = []) {
 			if (res.ok) {
 				return res.json()
 			} else {
+				// TODO 400 响应会进这里，因此错误似乎应该是 RESPONSE_ERROR
 				throw new Error(error.INVALID_RESPONSE)
 			}
 		}, () => {

--- a/src/core/query.js
+++ b/src/core/query.js
@@ -1,8 +1,8 @@
 import * as config from './config'
 import { get as getContract } from '../contract/index'
 import { isValidAddr } from '../util/index'
-import * as addr from '../util/addr'
 import * as error from '../const/error'
+import * as _addr from '../util/addr'
 
 /*
 从接口拿到的结果是一个 JSON 对象。
@@ -31,13 +31,11 @@ export function query(contractAddr, fnName, args = []) {
 	// get contract
 	const contract = isValidAddr(contractAddr) ?
 		contractAddr : getContract(contractAddr)
-	if (!contract) return Promise.reject(new Error(error.INVALID_ARG))
-
 	if (!contract || !fnName || !Array.isArray(args)) {
 		return Promise.reject(new Error(error.INVALID_ARG))
 	}
 
-	const randomAddr = addr.getAvailableAddr()
+	const randomAddr = _addr.getAvailableAddr()
 	// console.log(randomAddr)
 
 	const api = config.get('apiBaseUrl') + 'user/call'
@@ -63,6 +61,9 @@ export function query(contractAddr, fnName, args = []) {
 	})
 		.then((res) => {
 			if (res.ok) {
+				// 合法的合约地址也加入备用地址的池子
+				_addr.addAvailableAddr(contractAddr)
+
 				return res.json()
 			} else {
 				// TODO 400 响应会进这里，因此错误似乎应该是 RESPONSE_ERROR

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import * as util from './util/index'
 import * as user from './user/index'
 import * as env from './env/index'
 import * as contract from './contract/index'
+import { init } from './util/init'
 
 // ns
 const Nasa = {
@@ -30,6 +31,9 @@ const Nasa = {
 	env,
 	contract,
 }
+
+// init
+init()
 
 // exports to an namespace
 if (typeof ns !== 'undefined') {

--- a/src/util/addr.js
+++ b/src/util/addr.js
@@ -1,0 +1,47 @@
+import * as util from './index'
+
+// 预设的地址池
+const AVAILABLE_ADDR_LIST = [
+	'n1bCep7RbeCWQk9EQo48V3TuXEdZLCS7eTn',
+	'n1Q5ywsbu49mFV4RZSuq3URenNaxiWE4fxe',
+	'n1Qj7ynMBW77PCB4Q2EBrfRGQE73PR54VNe',
+	'n1YRjbJVRUP9kfpx92wHViJeU4owxLqzReZ',
+	'n1ZL7QLfm8UEbUqwEJ9zWBacN1yqk7biM3d',
+
+	'n1TnBAtXn2iUVaaTc5Q3BzwhfhJ9k5GH2Sk',
+	'n1GLeUeQKWYQPsm3TQBrpFcJR5CZDkFpZmV',
+	'n1ZAhvoHfwQzmVPKYKXUsAVyQTvZSKe5HcX',
+	'n1W9FLxZ1UBfRTWMMAAfM7nqUamcAQDk5io',
+	'n1bdxUCATAmr1RgffLaj9dNtqSXf5wCtfTk',
+]
+
+// 从池子中随机取一个地址来用
+function getAvailableAddr() {
+	const length = AVAILABLE_ADDR_LIST.length
+	const randomIndex = Math.floor(Math.random() * length)
+	return AVAILABLE_ADDR_LIST[randomIndex]
+}
+
+// 当得到有效地址时，放进池子
+function addAvailableAddr(addr) {
+	if (util.isValidAddr(addr)) {
+		// 重复加五次，表示随机选取时权重更高
+		for (let i = 0; i < 5; i++) {
+			AVAILABLE_ADDR_LIST.push(addr)
+		}
+	}
+}
+
+// 获得用户自己的地址之后，替换预设的地址
+function setAvailableAddr(addr) {
+	if (util.isValidAddr(addr)) {
+		AVAILABLE_ADDR_LIST.length = 0
+		AVAILABLE_ADDR_LIST.push(addr)
+	}
+}
+
+export {
+	getAvailableAddr,
+	addAvailableAddr,
+	setAvailableAddr,
+}

--- a/src/util/addr.js
+++ b/src/util/addr.js
@@ -27,8 +27,8 @@ function addAvailableAddr(addr) {
 	// 池子里只有一个备选地址，说明已经获取到用户自己的地址了，就没必要再往池子里加了
 	if (AVAILABLE_ADDR_LIST.length === 1) return
 	if (util.isValidAddr(addr) && !AVAILABLE_ADDR_LIST.includes(addr)) {
-		// 重复加五次，表示随机选取时权重更高
-		for (let i = 0; i < 5; i++) {
+		// 重复加 2 次，表示随机选取时权重更高
+		for (let i = 0; i < 2; i++) {
 			AVAILABLE_ADDR_LIST.push(addr)
 		}
 	}

--- a/src/util/addr.js
+++ b/src/util/addr.js
@@ -1,6 +1,6 @@
 import * as util from './index'
 
-// 预设的地址池
+// 备用地址池
 const AVAILABLE_ADDR_LIST = [
 	'n1bCep7RbeCWQk9EQo48V3TuXEdZLCS7eTn',
 	'n1Q5ywsbu49mFV4RZSuq3URenNaxiWE4fxe',
@@ -24,7 +24,9 @@ function getAvailableAddr() {
 
 // 当得到有效地址时，放进池子
 function addAvailableAddr(addr) {
-	if (util.isValidAddr(addr)) {
+	// 池子里只有一个备选地址，说明已经获取到用户自己的地址了，就没必要再往池子里加了
+	if (AVAILABLE_ADDR_LIST.length === 1) return
+	if (util.isValidAddr(addr) && !AVAILABLE_ADDR_LIST.includes(addr)) {
 		// 重复加五次，表示随机选取时权重更高
 		for (let i = 0; i < 5; i++) {
 			AVAILABLE_ADDR_LIST.push(addr)
@@ -39,6 +41,8 @@ function setAvailableAddr(addr) {
 		AVAILABLE_ADDR_LIST.push(addr)
 	}
 }
+
+// window.AVAILABLE_ADDR_LIST = AVAILABLE_ADDR_LIST
 
 export {
 	getAvailableAddr,

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -1,0 +1,9 @@
+import * as user from '../user/index'
+import * as _addr from '../util/addr'
+
+export function init() {
+	user.getAddr()
+		.then((addr) => {
+			_addr.setAvailableAddr(addr)
+		})
+}

--- a/src/util/init.js
+++ b/src/util/init.js
@@ -2,8 +2,10 @@ import * as user from '../user/index'
 import * as _addr from '../util/addr'
 
 export function init() {
-	user.getAddr()
-		.then((addr) => {
-			_addr.setAvailableAddr(addr)
-		})
+	document.addEventListener('DOMContentLoaded', () => {
+		user.getAddr()
+			.then((addr) => {
+				_addr.setAvailableAddr(addr)
+			})
+	}, false)
 }


### PR DESCRIPTION
***

> ⚠️ 这是一个 hotfix。

***

背景： #13 

方法：

* 增加内置地址的数量：1 → 10
* 缓存 `checkTx()` 接口返回的用户地址
* 缓存通过钱包扩展获取的用户地址
* 缓存 `query()` 接口调用的合约地址